### PR TITLE
watcher: Support async ops that return multiple docs

### DIFF
--- a/src/kuberlnetes_watcher.erl
+++ b/src/kuberlnetes_watcher.erl
@@ -23,18 +23,19 @@ loop(Callback, Func) ->
         ok -> ok;
         {status, 200} -> ok;
         done -> ok;
-        Obj -> callback_message(Callback, Obj)
+        Objects -> callback_message(Callback, Objects)
     end,
 
     loop(Callback, Func).
 
-callback_message(Callback, Msg) ->
-    % Type = maps:get(<<"type">>, Msg),
+callback_message(_Callback, []) ->
+    ok;
+callback_message(Callback, [Msg | Rest]) ->
     Type = maps:get(<<"type">>, Msg),
     Obj = maps:get(<<"object">>, Msg),
 
     Callback({Type, Obj}),
-    ok.
+    callback_message(Callback, Rest).
 
 callback_items(_Callback, []) ->
     ok;


### PR DESCRIPTION
Kubernetes can send multiple json docs as part of the same encoded
chunk. Updated swaggerl supports that now and the watcher needs to match
that interface